### PR TITLE
Fix utf-8 encoding string

### DIFF
--- a/lib/stimmung.rb
+++ b/lib/stimmung.rb
@@ -1,4 +1,4 @@
-#<Encoding:UTF-8>
+#encoding: utf-8
 
 class Stimmung
   attr_accessor :words


### PR DESCRIPTION
unknown encoding name "UTF-8>" for lib/stimmung.rb, skipping
